### PR TITLE
Fix error where intlTelInput was not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,7 @@ module.exports = {
       app.import(path.join(assetPath, 'js', 'utils.js'), importOptions);
     }
 
-    app.import({
-      development: path.join(assetPath, 'js', 'intlTelInput.js'),
-      production: path.join(assetPath, 'js', 'intlTelInput.js.min')
-    }, importOptions);
-
+    app.import(path.join(assetPath, 'js', 'intlTelInput.js'), importOptions);
     app.import(path.join(assetPath, 'css', 'intlTelInput.css'));
   },
 


### PR DESCRIPTION
It looks like there is an issue with the min version of intlTelInput causing an issue in production. We don't need it anyways since ember should minify the js for us.